### PR TITLE
remove google fonts dependency

### DIFF
--- a/src/oncall_admin/static/lumen.min.css
+++ b/src/oncall_admin/static/lumen.min.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700,400italic");/*!
+/*!
  * bootswatch v3.3.7
  * Homepage: http://bootswatch.com
  * Copyright 2012-2017 Thomas Park


### PR DESCRIPTION
We are using iris/oncall in a securised network zone without internet access.
So I've removed google fonts dependency..